### PR TITLE
Fix being unable to require es6-map on first attempt

### DIFF
--- a/node/ltnodeclient.js
+++ b/node/ltnodeclient.js
@@ -105,13 +105,14 @@ function sbRequire(require, resolve, path) {
   }
 
   var curSb = getSB(path);
-  if(typeof(curSb.module.exports) == "function" || Object.keys(curSb.module.exports).length) {
-    return curSb.module.exports;
+  var exports = curSb.module.exports;
+  if(typeof(exports) == "function" || ((typeof exports === 'object') && (exports !== null) && Object.keys(exports).length)) {
+    return exports;
   }
-  if(typeof(curSb.exports) == "function" || Object.keys(curSb.exports).length) {
+  if(typeof(curSb.exports) == "function" || ((typeof curSb.exports === 'object') && (curSb.exports !== null) && Object.keys(curSb.exports).length)) {
     return curSb.exports;
   }
-  return curSb.module.exports;
+  return exports;
 }
 
 


### PR DESCRIPTION
Fixes the require issue seen in LightTable/LightTable#1719 by ensuring we have an object before calling Object.keys on it.
@ibdknox Merging tomorrow unless you have a concern
